### PR TITLE
runner kubernetes: check for node taints

### DIFF
--- a/pkg/config/runner.go
+++ b/pkg/config/runner.go
@@ -13,6 +13,10 @@ limitations under the License.
 
 package config
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 // Runner structure with all available runners config options
 type Runner struct {
 	Name       string            `yaml:"name"`
@@ -40,7 +44,8 @@ type KubernetesTimeouts struct {
 
 // KubernetesHosts hosts selection options for Kubernetes
 type KubernetesHosts struct {
-	IgnoreSchedulingDisabled bool `yaml:"ignoreSchedulingDisabled"`
+	IgnoreSchedulingDisabled bool                `yaml:"ignoreSchedulingDisabled"`
+	Tolerations              []corev1.Toleration `yaml:"tolerations"`
 }
 
 // RunnerMock Mock Runner config options (here for good measure)

--- a/pkg/k8sutil/node.go
+++ b/pkg/k8sutil/node.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// INFO This code has been taken from the Rook project due to Golang dependency and modified to suite acntt's needs.
+// Original file https://github.com/rook/rook/blob/master/pkg/operator/k8sutil/node.go
+
+// NodeIsTolerable returns true if the node's taints are all tolerated by the given tolerations.
+// There is the option to ignore well known taints defined in WellKnownTaints. See WellKnownTaints
+// for more information.
+func NodeIsTolerable(node corev1.Node, tolerations []corev1.Toleration) bool {
+	for _, taint := range node.Spec.Taints {
+		isTolerated := false
+		for _, toleration := range tolerations {
+			if toleration.ToleratesTaint(&taint) {
+				isTolerated = true
+				break
+			}
+		}
+		if !isTolerated {
+			return false
+		}
+	}
+	return true
+}

--- a/runners/kubernetes_spec.go
+++ b/runners/kubernetes_spec.go
@@ -43,6 +43,7 @@ func (k Kubernetes) getPodSpec(pName string, taskName string, task *testers.Task
 			},
 			HostNetwork:   k.config.HostNetwork,
 			RestartPolicy: corev1.RestartPolicyOnFailure,
+			Tolerations:   k.config.Hosts.Tolerations,
 		},
 	}
 }

--- a/testdefinition.example.yaml
+++ b/testdefinition.example.yaml
@@ -12,6 +12,7 @@ runner:
       succeedTimeout: 60
     hosts:
       ignoreSchedulingDisabled: true
+      tolerations: []
 tests:
 - name: iperf3-one-rand-to-one-rand
   type: iperf3


### PR DESCRIPTION
This checks the taints of a node, if they are tolerated by the user
given .Hosts.Tolerations list. .Hosts.Tolerations is a new config
section in the Kubernetes Runner's Hosts structure.

Fixes #14.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>