### PR TITLE
*: fix the factories variable registration

### DIFF
--- a/cmd/acntt/imports.go
+++ b/cmd/acntt/imports.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 Cloudical Deutschland GmbH. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// This file contains the imports for each output, parser, runner and tester.
+// Importing them from the, e.g., `outputs` pkg would cause a import cycle.
+
+import (
+	// Outputs
+	_ "github.com/cloudical-io/acntt/outputs/csv"
+	_ "github.com/cloudical-io/acntt/outputs/dump"
+	_ "github.com/cloudical-io/acntt/outputs/excelize"
+	_ "github.com/cloudical-io/acntt/outputs/gochart"
+	_ "github.com/cloudical-io/acntt/outputs/mysql"
+	_ "github.com/cloudical-io/acntt/outputs/sqlite"
+	// Parsers
+	_ "github.com/cloudical-io/acntt/parsers/iperf3"
+	// Runners
+	_ "github.com/cloudical-io/acntt/runners/kubernetes"
+	_ "github.com/cloudical-io/acntt/runners/mock"
+	// Testers
+	_ "github.com/cloudical-io/acntt/testers/iperf3"
+	_ "github.com/cloudical-io/acntt/testers/siege"
+	_ "github.com/cloudical-io/acntt/testers/smokeping"
+)

--- a/outputs/csv/csv.go
+++ b/outputs/csv/csv.go
@@ -19,9 +19,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cloudical-io/acntt/outputs"
 	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/cloudical-io/acntt/pkg/util"
-	"github.com/cloudical-io/acntt/outputs"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )

--- a/outputs/dump/dump.go
+++ b/outputs/dump/dump.go
@@ -18,10 +18,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cloudical-io/acntt/outputs"
 	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/k0kubun/pp"
 	"github.com/sirupsen/logrus"
-	"github.com/cloudical-io/acntt/outputs"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/outputs/excelize/excelize.go
+++ b/outputs/excelize/excelize.go
@@ -16,9 +16,9 @@ package excelize
 import (
 	"os"
 
+	"github.com/cloudical-io/acntt/outputs"
 	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/sirupsen/logrus"
-	"github.com/cloudical-io/acntt/outputs"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/outputs/gochart/gochart.go
+++ b/outputs/gochart/gochart.go
@@ -17,10 +17,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/cloudical-io/acntt/outputs"
 	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/cloudical-io/acntt/pkg/util"
 	"github.com/sirupsen/logrus"
-	"github.com/cloudical-io/acntt/outputs"
 	log "github.com/sirupsen/logrus"
 	chart "github.com/wcharczuk/go-chart"
 )

--- a/outputs/mysql/mysql.go
+++ b/outputs/mysql/mysql.go
@@ -22,8 +22,8 @@ import (
 	// Include MySQL driver for mysql output
 	_ "github.com/go-sql-driver/mysql"
 
-	"github.com/sirupsen/logrus"
 	"github.com/cloudical-io/acntt/outputs"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/outputs/mysql/mysql_test.go
+++ b/outputs/mysql/mysql_test.go
@@ -18,9 +18,9 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/cloudical-io/acntt/outputs"
 	"github.com/cloudical-io/acntt/outputs/tests"
+	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/outputs/sqlite/sqlite.go
+++ b/outputs/sqlite/sqlite.go
@@ -23,8 +23,8 @@ import (
 	// Include sqlite driver for sqlite output
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/sirupsen/logrus"
 	"github.com/cloudical-io/acntt/outputs"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/outputs/sqlite/sqlite_test.go
+++ b/outputs/sqlite/sqlite_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/cloudical-io/acntt/outputs"
 	"github.com/cloudical-io/acntt/outputs/tests"
+	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/outputs/tests/mockdata.go
+++ b/outputs/tests/mockdata.go
@@ -14,8 +14,8 @@ limitations under the License.
 package tests
 
 import (
-	"time"
 	"github.com/cloudical-io/acntt/outputs"
+	"time"
 )
 
 func GenerateMockTableData(length int) outputs.Data {

--- a/parsers/iperf3/iperf3.go
+++ b/parsers/iperf3/iperf3.go
@@ -163,7 +163,7 @@ func (ip IPerf3) parse(input parsers.Input, dataCh chan<- outputs.Data) error {
 
 	// Transform Input into outputs.Data struct
 	data := outputs.Data{
-		TestStartTime:    input.TestStartTime,
+		TestStartTime:  input.TestStartTime,
 		TestTime:       input.TestTime,
 		AdditionalInfo: input.AdditionalInfo,
 		ServerHost:     input.ServerHost,

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -35,7 +35,7 @@ type Parser interface {
 
 // Input structured parse
 type Input struct {
-	TestStartTime    time.Time
+	TestStartTime  time.Time
 	TestTime       time.Time
 	Round          int
 	DataStream     *io.ReadCloser

--- a/runners/kubernetes/kubernetes.go
+++ b/runners/kubernetes/kubernetes.go
@@ -19,11 +19,11 @@ import (
 	"time"
 
 	"github.com/cloudical-io/acntt/parsers"
-	"github.com/cloudical-io/acntt/runners"
 	"github.com/cloudical-io/acntt/pkg/cmdtemplate"
 	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/cloudical-io/acntt/pkg/k8sutil"
 	"github.com/cloudical-io/acntt/pkg/util"
+	"github.com/cloudical-io/acntt/runners"
 	"github.com/cloudical-io/acntt/testers"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"

--- a/runners/mock/mock.go
+++ b/runners/mock/mock.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 
 	"github.com/cloudical-io/acntt/parsers"
-	"github.com/cloudical-io/acntt/runners"
 	"github.com/cloudical-io/acntt/pkg/config"
 	"github.com/cloudical-io/acntt/pkg/util"
+	"github.com/cloudical-io/acntt/runners"
 	"github.com/cloudical-io/acntt/testers"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"

--- a/testers/iperf3/iperf3.go
+++ b/testers/iperf3/iperf3.go
@@ -14,8 +14,8 @@ limitations under the License.
 package iperf3
 
 import (
-	"github.com/cloudical-io/acntt/testers"
 	"github.com/cloudical-io/acntt/pkg/config"
+	"github.com/cloudical-io/acntt/testers"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )

--- a/testers/siege/siege.go
+++ b/testers/siege/siege.go
@@ -15,8 +15,8 @@ package siege
 
 import (
 	"github.com/cloudical-io/acntt/pkg/config"
-	"github.com/sirupsen/logrus"
 	"github.com/cloudical-io/acntt/testers"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/testers/smokeping/smokeping.go
+++ b/testers/smokeping/smokeping.go
@@ -14,8 +14,8 @@ limitations under the License.
 package smokeping
 
 import (
-	"github.com/cloudical-io/acntt/testers"
 	"github.com/cloudical-io/acntt/pkg/config"
+	"github.com/cloudical-io/acntt/testers"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
Use an imports list in the "main" cmd package to include all outputs,
parsers, runners and testers.
Ran go fmt on all files with this change as well.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>