### PR TITLE
k8s: load all auth plugins

### DIFF
--- a/docs/config-structure.md
+++ b/docs/config-structure.md
@@ -8,10 +8,12 @@ This Document documents the types introduced by Ancientt for configuration to be
 
 * [AdditionalFlags](#additionalflags)
 * [AnsibleGroups](#ansiblegroups)
+* [AnsibleTimeouts](#ansibletimeouts)
 * [CSV](#csv)
 * [Config](#config)
 * [Dump](#dump)
 * [Excelize](#excelize)
+* [FilePath](#filepath)
 * [GoChart](#gochart)
 * [Hosts](#hosts)
 * [IPerf3](#iperf3)
@@ -50,14 +52,24 @@ AnsibleGroups server and clients host group names in the used inventory file(s)
 
 [Back to TOC](#table-of-contents)
 
+## AnsibleTimeouts
+
+AnsibleTimeouts timeouts for Ansible command runs
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| CommandTimeout | Timeout duration for `ansible` and `ansible-inventory` calls (NOT task command timeouts) | time.Duration | true |
+| TaskCommandTimeout | Timeout duration for `ansible` Task command calls | time.Duration | true |
+
+[Back to TOC](#table-of-contents)
+
 ## CSV
 
 CSV CSV Output config options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| FilePath | File base path for output | string | true |
-| NamePattern | File name pattern templated from various availables during output generation | string | true |
+| FilePath |  | [FilePath](#filepath) | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -79,8 +91,7 @@ Dump Dump Output config options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| FilePath | File base path for output | string | true |
-| NamePattern | File name pattern templated from various availables during output generation | string | true |
+| FilePath |  | [FilePath](#filepath) | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -90,9 +101,19 @@ Excelize Excelize Output config options. TODO implement
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
+| FilePath |  | [FilePath](#filepath) | false |
+| SaveAfterRows | After what amount of rows the Excel file should be saved | int | true |
+
+[Back to TOC](#table-of-contents)
+
+## FilePath
+
+FilePath file path and name pattern for outputs file generation
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
 | FilePath | File base path for output | string | true |
 | NamePattern | File name pattern templated from various availables during output generation | string | true |
-| SaveAfterRows | After what amount of rows the Excel file should be saved | int | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -102,8 +123,7 @@ GoChart GoChart Output config options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| FilePath | File base path for output | string | true |
-| NamePattern | File name pattern templated from various availables during output generation | string | true |
+| FilePath |  | [FilePath](#filepath) | false |
 | Types | Types of charts to produce from the testers output data | []string | true |
 
 [Back to TOC](#table-of-contents)
@@ -223,8 +243,7 @@ RunnerAnsible Ansible Runner config options
 | Groups | Groups server and clients group names | *[AnsibleGroups](#ansiblegroups) | true |
 | AnsibleCommand | Path to the ansible command (if empty will be searched for in `PATH`) | string | true |
 | AnsibleInventoryCommand | Path to the ansible-inventory command (if empty will be searched for in `PATH`) | string | true |
-| CommandTimeout | Timeout duration for `ansible` and `ansible-inventory` calls (NOT task command timeouts) | time.Duration | true |
-| TaskCommandTimeout | Timeout duration for `ansible` Task command calls | time.Duration | true |
+| Timeouts | Timeout settings for ansible command runs | *[AnsibleTimeouts](#ansibletimeouts) | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -235,8 +254,8 @@ RunnerKubernetes Kubernetes Runner config options
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | InClusterConfig | If the Kubernetes client should use the in-cluster config for the cluster communication | bool | true |
-| Kubeconfig | Path to your kubeconfig file, if not set the `KUBECONFIG` env var will be used and then the default | string | true |
-| Image | The image used for the spawned Pods for the tests (default: `quay.io/galexrt/container-toolbox`) | string | true |
+| Kubeconfig | Path to your kubeconfig file, if not set the following order will be tried out, `KUBECONFIG` and `$HOME/.kube/config` | string | true |
+| Image | The image used for the spawned Pods for the tests (default `quay.io/galexrt/container-toolbox`) | string | true |
 | Namespace | Namespace to execute the tests in | string | true |
 | HostNetwork | If `hostNetwork` mode should be used for the test Pods | bool | true |
 | Timeouts | Timeout settings for operations against the Kubernetes API | *[KubernetesTimeouts](#kubernetestimeouts) | true |
@@ -260,8 +279,7 @@ SQLite SQLite Output config options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| FilePath | File base path for output | string | true |
-| NamePattern | File name pattern templated from various availables during output generation | string | true |
+| FilePath |  | [FilePath](#filepath) | false |
 | TableNamePattern | Pattern used for templating the name of the table used in the SQLite database, the tables are created automatically | string | true |
 
 [Back to TOC](#table-of-contents)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9
 	github.com/mattn/go-sqlite3 v1.11.0
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/360EntSecGroup-Skylar/excelize/v2 v2.0.1 h1:gnknz1/4RnpL2fZsJzsqsGHgjWDT7k11tGPsFiDQeDk=
 github.com/360EntSecGroup-Skylar/excelize/v2 v2.0.1/go.mod h1:fkN+AZg31J/y9B4AtylxjzzNYetIxi6cElYu/WBUb7g=
+github.com/Azure/go-autorest v11.1.2+incompatible h1:viZ3tV5l4gE2Sw0xrasFHytCGtzYCrT+um/rrSQ1BfA=
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -16,6 +18,7 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda h1:NyywMz59neOoVRFDz+ccfKWxn784fiHMDnZSy6T+JXY=
 github.com/dgrijalva/jwt-go v0.0.0-20160705203006-01aeca54ebda/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
@@ -54,6 +57,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0 h1:rVsPeBmXbYv4If/cumu1AzZPwV58q433hvONV1UEZoI=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8 h1:L9JPKrtsHMQ4VCRQfHvbbHBfB2Urn8xf6QZeXZ+OrN4=
 github.com/gophercloud/gophercloud v0.0.0-20190126172459-c818fa66e4c8/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -101,6 +105,7 @@ github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2y
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,7 +136,7 @@ type Runner struct {
 type RunnerKubernetes struct {
 	// If the Kubernetes client should use the in-cluster config for the cluster communication
 	InClusterConfig bool `yaml:"inClusterConfig"`
-	// Path to your kubeconfig file, if not set the `KUBECONFIG` env var will be used and then the default
+	// Path to your kubeconfig file, if not set the following order will be tried out, `KUBECONFIG` and `$HOME/.kube/config`
 	Kubeconfig string `yaml:"kubeconfig"`
 	// The image used for the spawned Pods for the tests (default `quay.io/galexrt/container-toolbox`)
 	Image string `yaml:"image"`

--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 Cloudical Deutschland GmbH. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	// Load all k8s client auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/mitchellh/go-homedir"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// NewClient create a new Kubernetes clientset
+func NewClient(inClusterConfig bool, kubeconfig string) (kubernetes.Interface, error) {
+	var k8sconfig *rest.Config
+	if inClusterConfig {
+		var err error
+		k8sconfig, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("kubeconfig in-cluster configuration error. %+v", err)
+		}
+	} else {
+		var kubeconfig string
+		// Try to fallback to the `KUBECONFIG` env var
+		if kubeconfig == "" {
+			kubeconfig = os.Getenv("KUBECONFIG")
+		}
+		// If the `KUBECONFIG` is empty, default to home dir default kube config path
+		if kubeconfig == "" {
+			home, err := homedir.Dir()
+			if err != nil {
+				return nil, fmt.Errorf("kubeconfig unable to get home dir. %+v", err)
+			}
+			kubeconfig = filepath.Join(home, ".kube", "config")
+		}
+		var err error
+		// This will simply use the current context in the kubeconfig
+		k8sconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("kubeconfig out-of-cluster configuration (%s) error. %+v", kubeconfig, err)
+		}
+	}
+
+	// Create the clientset
+	clientset, err := kubernetes.NewForConfig(k8sconfig)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes new client error. %+v", err)
+	}
+	return clientset, nil
+}


### PR DESCRIPTION
This enables all k8s client auth plugins, so people should be able to
get their cluster credentials from those sources with ease when using
ancientt Kubernetes runner.

Additionally `$HOME/.kube/config` is now considered after `KUBECONFIG`
env var for the kubeconfig location.
The order after this change is: runner kubeconfig config option ->
`KUBECONFIG` env var -> `$HOME/.kube/config`.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>