### PR TITLE
runner:kubernetes: Allow users to specify ServiceAccount to be used for server and client Pods

### DIFF
--- a/cmd/docgen/api.go
+++ b/cmd/docgen/api.go
@@ -200,30 +200,36 @@ func wrapInLink(text, link string) string {
 // fieldName returns the name of the field as it should appear in JSON format
 // "-" indicates that this field is not part of the JSON representation
 func fieldName(field *ast.Field) string {
-	jsonTag := ""
+	tag := ""
 	if field.Tag != nil {
-		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
-		if strings.Contains(jsonTag, "inline") {
+		tag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+		if tag == "" {
+			tag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("yaml")
+		}
+		if strings.Contains(tag, "inline") {
 			return "-"
 		}
 	}
 
-	jsonTag = strings.Split(jsonTag, ",")[0] // This can return "-"
-	if jsonTag == "" {
+	tag = strings.Split(tag, ",")[0] // This can return "-"
+	if tag == "" {
 		if field.Names != nil {
 			return field.Names[0].Name
 		}
 		return field.Type.(*ast.Ident).Name
 	}
-	return jsonTag
+	return tag
 }
 
 // fieldRequired returns whether a field is a required field.
 func fieldRequired(field *ast.Field) bool {
-	jsonTag := ""
+	tag := ""
 	if field.Tag != nil {
-		jsonTag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
-		return !strings.Contains(jsonTag, "omitempty")
+		tag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("json") // Delete first and last quotation
+		if tag == "" {
+			tag = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get("yaml")
+		}
+		return !strings.Contains(tag, "omitempty")
 	}
 
 	return false

--- a/docs/config-structure.md
+++ b/docs/config-structure.md
@@ -18,6 +18,7 @@ This Document documents the types introduced by Ancientt for configuration to be
 * [Hosts](#hosts)
 * [IPerf3](#iperf3)
 * [KubernetesHosts](#kuberneteshosts)
+* [KubernetesServiceAccounts](#kubernetesserviceaccounts)
 * [KubernetesTimeouts](#kubernetestimeouts)
 * [MySQL](#mysql)
 * [Output](#output)
@@ -36,8 +37,8 @@ AdditionalFlags additional flags structure for Server and Clients
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| Clients | \n List of additional flags for clients | []string | true |
-| Server | \n List of additional flags for server | []string | true |
+| clients | \n List of additional flags for clients | []string | true |
+| server | \n List of additional flags for server | []string | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -47,8 +48,8 @@ AnsibleGroups server and clients host group names in the used inventory file(s)
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| Server | Server inventory server group name | string | true |
-| Clients | Clients inventory clients group name | string | true |
+| server | Server inventory server group name | string | true |
+| clients | Clients inventory clients group name | string | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -58,8 +59,8 @@ AnsibleTimeouts timeouts for Ansible command runs
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| CommandTimeout | Timeout duration for `ansible` and `ansible-inventory` calls (NOT task command timeouts) | time.Duration | true |
-| TaskCommandTimeout | Timeout duration for `ansible` Task command calls | time.Duration | true |
+| commandTimeout | Timeout duration for `ansible` and `ansible-inventory` calls (NOT task command timeouts) | time.Duration | true |
+| taskCommandTimeout | Timeout duration for `ansible` Task command calls | time.Duration | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -79,9 +80,9 @@ Config Config object for the config file
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| Version |  | string | true |
-| Runner |  | [Runner](#runner) | true |
-| Tests |  | []*[Test](#test) | true |
+| version |  | string | true |
+| runner |  | [Runner](#runner) | true |
+| tests |  | []*[Test](#test) | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -102,7 +103,7 @@ Excelize Excelize Output config options. TODO implement
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | FilePath |  | [FilePath](#filepath) | false |
-| SaveAfterRows | After what amount of rows the Excel file should be saved | int | true |
+| saveAfterRows | After what amount of rows the Excel file should be saved | int | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -112,8 +113,8 @@ FilePath file path and name pattern for outputs file generation
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| FilePath | File base path for output | string | true |
-| NamePattern | File name pattern templated from various availables during output generation | string | true |
+| filePath | File base path for output | string | true |
+| namePattern | File name pattern templated from various availables during output generation | string | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -124,7 +125,7 @@ GoChart GoChart Output config options
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | FilePath |  | [FilePath](#filepath) | false |
-| Types | Types of charts to produce from the testers output data | []string | true |
+| types | Types of charts to produce from the testers output data | []string | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -134,13 +135,13 @@ Hosts options for hosts selection for a Test
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| Name | Name of this hosts selection. | string | true |
-| All | If all hosts available should be used. | bool | true |
-| Random | Select `Count` Random hosts from the available hosts list. | bool | true |
-| Count | Must be used with `Random`, will cause `Count` times Nodes to be randomly selected from all applicable hosts. | int | true |
-| Hosts | Static list of hosts (this list is not checked for accuracy) | []string | true |
-| HostSelector | \"Label\" selector for the dynamically generated hosts list, e.g., Kubernetes label selector | map[string]string | true |
-| AntiAffinity | AntiAffinity not implemented yet | []string | true |
+| name | Name of this hosts selection. | string | true |
+| all | If all hosts available should be used. | bool | true |
+| random | Select `Count` Random hosts from the available hosts list. | bool | true |
+| count | Must be used with `Random`, will cause `Count` times Nodes to be randomly selected from all applicable hosts. | int | true |
+| hosts | Static list of hosts (this list is not checked for accuracy) | []string | true |
+| hostSelector | \"Label\" selector for the dynamically generated hosts list, e.g., Kubernetes label selector | map[string]string | true |
+| antiAffinity | AntiAffinity not implemented yet | []string | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -150,8 +151,8 @@ IPerf3 IPerf3 config structure for testers.Tester config
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| AdditionalFlags | Additional flags for client and server | [AdditionalFlags](#additionalflags) | true |
-| UDP | If UDP should be used for the IPerf3 test | *bool | true |
+| additionalFlags | Additional flags for client and server | [AdditionalFlags](#additionalflags) | true |
+| udp | If UDP should be used for the IPerf3 test | *bool | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -161,8 +162,19 @@ KubernetesHosts hosts selection options for Kubernetes
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| IgnoreSchedulingDisabled | If Nodes that are `SchedulingDisabled` should be ignored | bool | true |
-| Tolerations | List of Kubernetes corev1.Toleration to tolerate when selecting Nodes | [][corev1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#toleration-v1-core) | true |
+| ignoreSchedulingDisabled | If Nodes that are `SchedulingDisabled` should be ignored | *bool | true |
+| tolerations | List of Kubernetes corev1.Toleration to tolerate when selecting Nodes | [][corev1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#toleration-v1-core) | true |
+
+[Back to TOC](#table-of-contents)
+
+## KubernetesServiceAccounts
+
+KubernetesServiceAccounts server and client ServiceAccount name to use for the created Pods
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| server | Server ServiceAccount name to use for server Pods | string | false |
+| clients | Clients ServiceAccount name to use for client Pods | string | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -172,9 +184,9 @@ KubernetesTimeouts timeouts for operations with Kubernetess
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| DeleteTimeout | Timeout for object deletion | int | true |
-| RunningTimeout | Timeout for \"Pod running\" check | int | true |
-| SucceedTimeout | Timeout for \"Pod succeded\" check (e.g., client Pod exits after Pod) | int | true |
+| deleteTimeout | Timeout for object deletion | int | true |
+| runningTimeout | Timeout for \"Pod running\" check | int | true |
+| succeedTimeout | Timeout for \"Pod succeded\" check (e.g., client Pod exits after Pod) | int | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -184,9 +196,9 @@ MySQL MySQL Output config options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| DSN | MySQL DSN, format `[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]`, for more information see https://github.com/go-sql-driver/mysql#dsn-data-source-name | string | true |
-| TableNamePattern | Pattern used for templating the name of the table used in the MySQL database, the tables are created automatically when MySQL.AutoCreateTables is set to `true` | string | true |
-| AutoCreateTables | Automatically create tables in the MySQL database (default `true`) | *bool | true |
+| dsn | MySQL DSN, format `[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]`, for more information see https://github.com/go-sql-driver/mysql#dsn-data-source-name | string | true |
+| tableNamePattern | Pattern used for templating the name of the table used in the MySQL database, the tables are created automatically when MySQL.AutoCreateTables is set to `true` | string | true |
+| autoCreateTables | Automatically create tables in the MySQL database (default `true`) | *bool | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -196,13 +208,13 @@ Output Output config structure pointing to the other config options for each out
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| Name | Name of this output | string | true |
-| CSV | CSV output options | *[CSV](#csv) | true |
-| GoChart | GoChart output options | *[GoChart](#gochart) | true |
-| Dump | Dump output options | *[Dump](#dump) | true |
-| Excelize | Excelize output options | *[Excelize](#excelize) | true |
-| SQLite | SQLite output options | *[SQLite](#sqlite) | true |
-| MySQL | MySQL output options | *[MySQL](#mysql) | true |
+| name | Name of this output | string | true |
+| csv | CSV output options | *[CSV](#csv) | true |
+| goChart | GoChart output options | *[GoChart](#gochart) | true |
+| dump | Dump output options | *[Dump](#dump) | true |
+| excelize | Excelize output options | *[Excelize](#excelize) | true |
+| sqlite | SQLite output options | *[SQLite](#sqlite) | true |
+| mysql | MySQL output options | *[MySQL](#mysql) | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -212,11 +224,11 @@ RunOptions options for running the tasks
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| ContinueOnError |  | bool | true |
-| Rounds | Amount of test rounds (repetitions) to do for a test plan | int | true |
-| Interval | Time interval to sleep / wait between | time.Duration | true |
-| Mode | Run mode can be `parallel` or `sequential` (default is `sequential`) | string | true |
-| ParallelCount | **NOT IMPLEMENTED YET** amount of test tasks to run when using `parallel` RunOptions.Mode | int | true |
+| continueOnError |  | bool | true |
+| rounds | Amount of test rounds (repetitions) to do for a test plan | int | true |
+| interval | Time interval to sleep / wait between | time.Duration | true |
+| mode | Run mode can be `parallel` or `sequential` (default is `sequential`) | string | true |
+| parallelCount | **NOT IMPLEMENTED YET** amount of test tasks to run when using `parallel` RunOptions.Mode | int | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -226,10 +238,10 @@ Runner structure with all available runners config options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| Name | Name of the runner | string | true |
-| Kubernetes | Kubernetes runner options | *[RunnerKubernetes](#runnerkubernetes) | true |
-| Ansible | Ansible runner options | *[RunnerAnsible](#runneransible) | true |
-| Mock | Mock runner options (userd for testing purposes) | *[RunnerMock](#runnermock) | true |
+| name | Name of the runner | string | true |
+| kubernetes | Kubernetes runner options | *[RunnerKubernetes](#runnerkubernetes) | true |
+| ansible | Ansible runner options | *[RunnerAnsible](#runneransible) | true |
+| mock | Mock runner options (userd for testing purposes) | *[RunnerMock](#runnermock) | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -239,11 +251,11 @@ RunnerAnsible Ansible Runner config options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| InventoryFilePath | InventoryFilePath Path to inventory file to use | string | true |
-| Groups | Groups server and clients group names | *[AnsibleGroups](#ansiblegroups) | true |
-| AnsibleCommand | Path to the ansible command (if empty will be searched for in `PATH`) | string | true |
-| AnsibleInventoryCommand | Path to the ansible-inventory command (if empty will be searched for in `PATH`) | string | true |
-| Timeouts | Timeout settings for ansible command runs | *[AnsibleTimeouts](#ansibletimeouts) | true |
+| inventoryFilePath | InventoryFilePath Path to inventory file to use | string | true |
+| groups | Groups server and clients group names | *[AnsibleGroups](#ansiblegroups) | true |
+| ansibleCommand | Path to the ansible command (if empty will be searched for in `PATH`) | string | true |
+| ansibleInventoryCommand | Path to the ansible-inventory command (if empty will be searched for in `PATH`) | string | true |
+| timeouts | Timeout settings for ansible command runs | *[AnsibleTimeouts](#ansibletimeouts) | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -253,14 +265,15 @@ RunnerKubernetes Kubernetes Runner config options
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| InClusterConfig | If the Kubernetes client should use the in-cluster config for the cluster communication | bool | true |
-| Kubeconfig | Path to your kubeconfig file, if not set the following order will be tried out, `KUBECONFIG` and `$HOME/.kube/config` | string | true |
-| Image | The image used for the spawned Pods for the tests (default `quay.io/galexrt/container-toolbox`) | string | true |
-| Namespace | Namespace to execute the tests in | string | true |
-| HostNetwork | If `hostNetwork` mode should be used for the test Pods | bool | true |
-| Timeouts | Timeout settings for operations against the Kubernetes API | *[KubernetesTimeouts](#kubernetestimeouts) | true |
-| Annotations | Annotations to put on the test Pods | map[string]string | true |
-| Hosts | Host selection specific options | *[KubernetesHosts](#kuberneteshosts) | true |
+| inClusterConfig | If the Kubernetes client should use the in-cluster config for the cluster communication | bool | true |
+| kubeconfig | Path to your kubeconfig file, if not set the following order will be tried out, `KUBECONFIG` and `$HOME/.kube/config` | string | false |
+| image | The image used for the spawned Pods for the tests (default `quay.io/galexrt/container-toolbox`) | string | true |
+| namespace | Namespace to execute the tests in | string | true |
+| hostNetwork | If `hostNetwork` mode should be used for the test Pods | *bool | false |
+| timeouts | Timeout settings for operations against the Kubernetes API | *[KubernetesTimeouts](#kubernetestimeouts) | false |
+| annotations | Annotations to put on the test Pods | map[string]string | false |
+| hosts | Host selection specific options | *[KubernetesHosts](#kuberneteshosts) | true |
+| serviceaccounts | ServiceAccounst to use server and client Pods | *[KubernetesServiceAccounts](#kubernetesserviceaccounts) | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -280,7 +293,7 @@ SQLite SQLite Output config options
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | FilePath |  | [FilePath](#filepath) | false |
-| TableNamePattern | Pattern used for templating the name of the table used in the SQLite database, the tables are created automatically | string | true |
+| tableNamePattern | Pattern used for templating the name of the table used in the SQLite database, the tables are created automatically | string | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -290,12 +303,12 @@ Test Config options for each Test
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| Name | Test name | string | true |
-| Type | The tester to use, e.g., for `iperf3` set to `iperf3` and so on | string | true |
-| RunOptions | Options for the execution of the test | [RunOptions](#runoptions) | true |
-| Outputs | List of Outputs to use for processing data from the testers. | [][Output](#output) | true |
-| Hosts | Hosts selection for client and server | [TestHosts](#testhosts) | true |
-| IPerf3 | IPerf3 test options | *[IPerf3](#iperf3) | true |
+| name | Test name | string | true |
+| type | The tester to use, e.g., for `iperf3` set to `iperf3` and so on | string | true |
+| runOptions | Options for the execution of the test | [RunOptions](#runoptions) | true |
+| outputs | List of Outputs to use for processing data from the testers. | [][Output](#output) | true |
+| hosts | Hosts selection for client and server | [TestHosts](#testhosts) | true |
+| iperf3 | IPerf3 test options | *[IPerf3](#iperf3) | true |
 
 [Back to TOC](#table-of-contents)
 
@@ -305,7 +318,7 @@ TestHosts list of clients and servers hosts for use in the test(s)
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| Clients | Static list of hosts to use as clients | [][Hosts](#hosts) | true |
-| Servers | Static list of hosts to use as server | [][Hosts](#hosts) | true |
+| clients | Static list of hosts to use as clients | [][Hosts](#hosts) | true |
+| servers | Static list of hosts to use as server | [][Hosts](#hosts) | true |
 
 [Back to TOC](#table-of-contents)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,19 +137,21 @@ type RunnerKubernetes struct {
 	// If the Kubernetes client should use the in-cluster config for the cluster communication
 	InClusterConfig bool `yaml:"inClusterConfig"`
 	// Path to your kubeconfig file, if not set the following order will be tried out, `KUBECONFIG` and `$HOME/.kube/config`
-	Kubeconfig string `yaml:"kubeconfig"`
+	Kubeconfig string `yaml:"kubeconfig,omitempty"`
 	// The image used for the spawned Pods for the tests (default `quay.io/galexrt/container-toolbox`)
 	Image string `yaml:"image"`
 	// Namespace to execute the tests in
 	Namespace string `yaml:"namespace" validate:"max=63"`
 	// If `hostNetwork` mode should be used for the test Pods
-	HostNetwork bool `yaml:"hostNetwork"`
+	HostNetwork *bool `yaml:"hostNetwork,omitempty"`
 	// Timeout settings for operations against the Kubernetes API
-	Timeouts *KubernetesTimeouts `yaml:"timeouts"`
+	Timeouts *KubernetesTimeouts `yaml:"timeouts,omitempty"`
 	// Annotations to put on the test Pods
-	Annotations map[string]string `yaml:"annotations"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 	// Host selection specific options
 	Hosts *KubernetesHosts `yaml:"hosts"`
+	// ServiceAccounst to use server and client Pods
+	ServiceAccounts *KubernetesServiceAccounts `yaml:"serviceaccounts,omitempty"`
 }
 
 // KubernetesTimeouts timeouts for operations with Kubernetess
@@ -165,9 +167,17 @@ type KubernetesTimeouts struct {
 // KubernetesHosts hosts selection options for Kubernetes
 type KubernetesHosts struct {
 	// If Nodes that are `SchedulingDisabled` should be ignored
-	IgnoreSchedulingDisabled bool `yaml:"ignoreSchedulingDisabled"`
+	IgnoreSchedulingDisabled *bool `yaml:"ignoreSchedulingDisabled"`
 	// List of Kubernetes corev1.Toleration to tolerate when selecting Nodes
 	Tolerations []corev1.Toleration `yaml:"tolerations"`
+}
+
+// KubernetesServiceAccounts server and client ServiceAccount name to use for the created Pods
+type KubernetesServiceAccounts struct {
+	// Server ServiceAccount name to use for server Pods
+	Server string `yaml:"server,omitempty"`
+	// Clients ServiceAccount name to use for client Pods
+	Clients string `yaml:"clients,omitempty"`
 }
 
 // RunnerAnsible Ansible Runner config options

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -16,8 +16,9 @@ package config
 import (
 	"time"
 
+	"github.com/cloudical-io/ancientt/pkg/util"
+
 	"github.com/cloudical-io/ancientt/pkg/ansible"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // Defaults interface to implement for config parts which allow a "verification" / Setting Defaults
@@ -35,33 +36,32 @@ func (c *RunnerKubernetes) SetDefaults() {
 		c.Image = "quay.io/galexrt/container-toolbox:latest"
 	}
 
-	if c.Hosts == nil {
-		c.Hosts = &KubernetesHosts{
-			IgnoreSchedulingDisabled: true,
-			Tolerations:              []corev1.Toleration{},
-		}
-	}
-
 	if c.Namespace == "" {
 		c.Namespace = "ancientt"
 	}
+}
 
-	if c.Timeouts == nil {
-		c.Timeouts = &KubernetesTimeouts{}
-	}
-	if c.Timeouts.DeleteTimeout == 0 {
-		c.Timeouts.DeleteTimeout = 20
-	}
-	c.Timeouts.RunningTimeout = 35
-	if c.Timeouts.SucceedTimeout == 0 {
-		c.Timeouts.RunningTimeout = 35
-	}
-	if c.Timeouts.SucceedTimeout == 0 {
-		c.Timeouts.SucceedTimeout = 60
+// SetDefaults set defaults on config part
+func (c *KubernetesHosts) SetDefaults() {
+	if c.IgnoreSchedulingDisabled == nil {
+		c.IgnoreSchedulingDisabled = util.BoolPointer(true)
 	}
 }
 
-// SetDefaults set default on config part
+// SetDefaults set defaults on config part
+func (c *KubernetesTimeouts) SetDefaults() {
+	if c.DeleteTimeout == 0 {
+		c.DeleteTimeout = 20
+	}
+	if c.RunningTimeout == 0 {
+		c.RunningTimeout = 35
+	}
+	if c.SucceedTimeout == 0 {
+		c.SucceedTimeout = 60
+	}
+}
+
+// SetDefaults set defaults on config part
 func (c *RunnerAnsible) SetDefaults() {
 	if c.AnsibleCommand == "" {
 		c.AnsibleCommand = ansible.AnsibleCommand

--- a/pkg/hostsfilter/hostfilter_test.go
+++ b/pkg/hostsfilter/hostfilter_test.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package hostsfilter
 
 import (
 	"testing"

--- a/pkg/hostsfilter/hostsfilter.go
+++ b/pkg/hostsfilter/hostsfilter.go
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package hostsfilter
 
 import (
 	"math/rand"

--- a/pkg/util/names.go
+++ b/pkg/util/names.go
@@ -16,8 +16,7 @@ package util
 import (
 	"crypto/sha1"
 	"fmt"
-
-	"github.com/cloudical-io/ancientt/testers"
+	"time"
 )
 
 // PNameRole task role names type
@@ -32,12 +31,12 @@ const (
 
 // GetPNameFromTask get a "persistent" name for a task
 // This is done by calculating the checksums of the used names.
-func GetPNameFromTask(round int, task *testers.Task, role PNameRole) string {
-	data := fmt.Sprintf("%d-%s-%s", round, task.Host.Name, task.Args)
-	return fmt.Sprintf("ancientt-%s-%s-%x", role, task.Command, sha1.Sum([]byte(data)))
+func GetPNameFromTask(round int, hostname string, command string, args []string, role PNameRole) string {
+	data := fmt.Sprintf("%d-%s-%s", round, hostname, args)
+	return fmt.Sprintf("ancientt-%s-%s-%x", role, command, sha1.Sum([]byte(data)))
 }
 
 // GetTaskName get a task name
-func GetTaskName(plan *testers.Plan) string {
-	return fmt.Sprintf("ancientt-%s-%d", plan.Tester, plan.TestStartTime.Unix())
+func GetTaskName(tester string, testStartTime time.Time) string {
+	return fmt.Sprintf("ancientt-%s-%d", tester, testStartTime.Unix())
 }

--- a/runners/ansible/ansible.go
+++ b/runners/ansible/ansible.go
@@ -236,7 +236,7 @@ func (a *Ansible) Execute(plan *testers.Plan, parser chan<- parsers.Input) error
 			}
 			a.logger.Infof("running task round %d of %d", i+1, len(tasks))
 
-			if err := a.runTasks(round, task, plan.TestStartTime, plan.Tester, util.GetTaskName(plan), parser); err != nil {
+			if err := a.runTasks(round, task, plan.TestStartTime, plan.Tester, util.GetTaskName(plan.Tester, plan.TestStartTime), parser); err != nil {
 				if !plan.RunOptions.ContinueOnError {
 					return err
 				}

--- a/runners/kubernetes/kubernetes_test.go
+++ b/runners/kubernetes/kubernetes_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cloudical-io/ancientt/pkg/config"
 	"github.com/cloudical-io/ancientt/tests/k8s"
+	"github.com/creasty/defaults"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,8 @@ func TestGetHostsForTest(t *testing.T) {
 	require.NotNil(t, clientset)
 
 	conf := &config.RunnerKubernetes{}
-	conf.SetDefaults()
+	// Set defaults in the config struct
+	require.Nil(t, defaults.Set(conf))
 
 	runner := &Kubernetes{
 		logger:    log.WithFields(logrus.Fields{"runner": Name, "namespace": ""}),

--- a/runners/kubernetes/spec.go
+++ b/runners/kubernetes/spec.go
@@ -20,8 +20,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	clientsRole = "clients"
+	serverRole  = "server"
+)
+
 func (k Kubernetes) getPodSpec(pName string, taskName string, task *testers.Task) *corev1.Pod {
-	return &corev1.Pod{
+	hostNetwork := false
+	if *k.config.HostNetwork {
+		hostNetwork = true
+	}
+
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: k.config.Annotations,
 			Labels:      k8sutil.GetPodLabels(pName, taskName),
@@ -41,9 +51,26 @@ func (k Kubernetes) getPodSpec(pName string, taskName string, task *testers.Task
 			NodeSelector: map[string]string{
 				corev1.LabelHostname: task.Host.Name,
 			},
-			HostNetwork:   k.config.HostNetwork,
+			HostNetwork:   hostNetwork,
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Tolerations:   k.config.Hosts.Tolerations,
 		},
+	}
+
+	return pod
+}
+
+func (k Kubernetes) applyServiceAccountToPod(p *corev1.Pod, role string) {
+	if k.config.ServiceAccounts != nil {
+		switch role {
+		case serverRole:
+			if k.config.ServiceAccounts.Server != "" {
+				p.Spec.ServiceAccountName = k.config.ServiceAccounts.Server
+			}
+		case clientsRole:
+			if k.config.ServiceAccounts.Clients != "" {
+				p.Spec.ServiceAccountName = k.config.ServiceAccounts.Clients
+			}
+		}
 	}
 }

--- a/runners/mock/mock.go
+++ b/runners/mock/mock.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/cloudical-io/ancientt/parsers"
 	"github.com/cloudical-io/ancientt/pkg/config"
-	"github.com/cloudical-io/ancientt/pkg/util"
+	"github.com/cloudical-io/ancientt/pkg/hostsfilter"
 	"github.com/cloudical-io/ancientt/runners"
 	"github.com/cloudical-io/ancientt/testers"
 	"github.com/sirupsen/logrus"
@@ -60,7 +60,7 @@ func (m Mock) GetHostsForTest(test *config.Test) (*testers.Hosts, error) {
 
 	// Go through Hosts Servers list to get the servers hosts
 	for _, servers := range test.Hosts.Servers {
-		filtered, err := util.FilterHostsList(mockHosts, servers)
+		filtered, err := hostsfilter.FilterHostsList(mockHosts, servers)
 		if err != nil {
 			return nil, err
 		}
@@ -73,7 +73,7 @@ func (m Mock) GetHostsForTest(test *config.Test) (*testers.Hosts, error) {
 
 	// Go through Hosts Clients list to get the clients hosts
 	for _, clients := range test.Hosts.Clients {
-		filtered, err := util.FilterHostsList(mockHosts, clients)
+		filtered, err := hostsfilter.FilterHostsList(mockHosts, clients)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
docgen: correctly use `yaml` tags when available

Pick up `yaml` tags when available besides `json` tags for the field
name.

runner:kubernetes: added serviceaccount config

This allows users to specify which ServiceAccount to use for the created client and
server Pods.
In addition to that some code around the config pkg has been improved.

***

Resolves #40.