### PR TITLE
ci: fix golang v1.12 to use go mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: go
 
+env:
+  # Remove when dropping Go 1.12 CI support
+  - GO111MODULE=on
+
 go:
   - '1.12'
   - '1.13'
 
 script:
-- make test
+  - make test # Run tests

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ GOFMT   := gofmt
 PREFIX  ?= $(shell pwd)
 VERSION ?= $(shell cat VERSION)
 
+GO_TEST_FLAGS ?= -race
+
 pkgs = $(shell go list ./... | grep -v /vendor/ | grep -v /test/)
 
 DOCKER_IMAGE_NAME ?= ancientt
@@ -40,7 +42,7 @@ style: go.check
 
 test: go.check
 	@echo ">> running tests"
-	$(GO) test $(pkgs)
+	$(GO) test $(GO_TEST_FLAGS) $(pkgs)
 
 test-short: go.check
 	@echo ">> running short tests"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [Demos](docs/demos.md).
 
 ## Development
 
-**Golang version**: `v1.12` or higher (tested with `v1.12.7` on `linux/amd64`)
+**Golang version**: `v1.12` or higher (tested with `v1.12.9` on `linux/amd64`)
 
 ### Dependencies
 


### PR DESCRIPTION
Enable go mod support by env var for golang v1.12.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>