### PR TITLE
csvoutput: make separator configurable

### DIFF
--- a/docs/config-structure.md
+++ b/docs/config-structure.md
@@ -70,6 +70,7 @@ CSV CSV Output config options
 
 | Field | Description | Scheme | Required | Validation |
 | ----- | ----------- | ------ | -------- | ---------- |
+| separator | Separator which rune to use as a separator in the CSV file (default: `;`). | *rune | true |  |
 
 [Back to TOC](#table-of-contents)
 

--- a/outputs/csv/csv.go
+++ b/outputs/csv/csv.go
@@ -83,6 +83,7 @@ func (c CSV) Do(data outputs.Data) error {
 		}
 
 		writer = csv.NewWriter(file)
+		writer.Comma = *c.config.Separator
 		c.writers[outPath] = writer
 		writeHeaders = true
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,8 @@ type CSV struct {
 	// FilePath struct fields which are inherited by this struct.
 	// The fields of the FilePath struct must be written directly to this struct.
 	FilePath `yaml:",inline"`
+	// Separator which rune to use as a separator in the CSV file (default: `;`).
+	Separator *rune `yaml:"separator"`
 }
 
 // GoChart GoChart Output config options

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -153,3 +153,11 @@ func (c *MySQL) SetDefaults() {
 		c.AutoCreateTables = util.BoolTruePointer()
 	}
 }
+
+// SetDefaults set defaults on config part
+func (c *CSV) SetDefaults() {
+	if c.Separator == nil {
+		semiColon := ';'
+		c.Separator = &semiColon
+	}
+}


### PR DESCRIPTION
This makes the separator for the CSV output configurable.
In addition to that the default is changed from comma to a semicolon so
it the CSV files can be opened "instantly" in Excel.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>