### PR TITLE
tester: iperf3: interval and duration configurable

### DIFF
--- a/docs/config-structure.md
+++ b/docs/config-structure.md
@@ -149,6 +149,8 @@ IPerf3 IPerf3 config structure for testers.Tester config
 | Field | Description | Scheme | Required | Validation |
 | ----- | ----------- | ------ | -------- | ---------- |
 | additionalFlags | Additional flags for client and server | [AdditionalFlags](#additionalflags) | false |  |
+| duration | Duration Time in seconds the IPerf3 test should transmit / receive (default: `10`). In case of the Ansible Runner, you need to increase the `taskCommandTimeout` when increasing the Duration. The `taskCommandTimeout` should then be set to `Duration` + some extra, e.g., 10 seconds. | *int | false | required,min=1 |
+| interval | Interval Interval in which IPerf3 will print / return periodic throughput reports (default: `1`). | *int | false | required,min=1 |
 | udp | If UDP should be used for the IPerf3 test | *bool | false |  |
 
 [Back to TOC](#table-of-contents)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -293,6 +293,12 @@ type AdditionalFlags struct {
 type IPerf3 struct {
 	// Additional flags for client and server
 	AdditionalFlags AdditionalFlags `yaml:"additionalFlags,omitempty"`
+	// Duration Time in seconds the IPerf3 test should transmit / receive (default: `10`).
+	// In case of the Ansible Runner, you need to increase the `taskCommandTimeout` when
+	// increasing the Duration. The `taskCommandTimeout` should then be set to `Duration` + some extra, e.g., 10 seconds.
+	Duration *int `yaml:"duration,omitempty" validate:"required,min=1"`
+	// Interval Interval in which IPerf3 will print / return periodic throughput reports (default: `1`).
+	Interval *int `yaml:"interval,omitempty" validate:"required,min=1"`
 	// If UDP should be used for the IPerf3 test
 	UDP *bool `yaml:"udp,omitempty"`
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -125,6 +125,16 @@ func (c *RunOptions) SetDefaults() {
 
 // SetDefaults set defaults config part
 func (c *IPerf3) SetDefaults() {
+	if c.Duration == nil {
+		defValue := 10
+		c.Duration = &defValue
+	}
+
+	if c.Interval == nil {
+		defValue := 1
+		c.Interval = &defValue
+	}
+
 	if c.UDP == nil {
 		c.UDP = util.BoolFalsePointer()
 	}

--- a/testers/iperf3/iperf3.go
+++ b/testers/iperf3/iperf3.go
@@ -14,6 +14,8 @@ limitations under the License.
 package iperf3
 
 import (
+	"fmt"
+
 	"github.com/cloudical-io/ancientt/pkg/config"
 	"github.com/cloudical-io/ancientt/testers"
 	"github.com/sirupsen/logrus"
@@ -148,6 +150,8 @@ func (ip IPerf3) buildIPerf3ClientCommand(server *testers.Host, client *testers.
 	// Base command and args
 	cmd := "iperf3"
 	args := []string{
+		fmt.Sprintf("--time=%d", ip.config.Duration),
+		fmt.Sprintf("--interval=%d", ip.config.Interval),
 		"--json",
 		"--port={{ .ServerPort }}",
 		"--client={{ .ServerAddressV4 }}",


### PR DESCRIPTION
IPerf3 tester now allows the interval and duration to be configured in
the testdefinition `IPerf3` struct.
A note has been added about the Ansible runner as the timeouts need to
be adjusted manually right now.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>