### PR TITLE
testers: iperf3: fix usage of duration and interval

### DIFF
--- a/testers/iperf3/iperf3.go
+++ b/testers/iperf3/iperf3.go
@@ -150,8 +150,8 @@ func (ip IPerf3) buildIPerf3ClientCommand(server *testers.Host, client *testers.
 	// Base command and args
 	cmd := "iperf3"
 	args := []string{
-		fmt.Sprintf("--time=%d", ip.config.Duration),
-		fmt.Sprintf("--interval=%d", ip.config.Interval),
+		fmt.Sprintf("--time=%d", *ip.config.Duration),
+		fmt.Sprintf("--interval=%d", *ip.config.Interval),
 		"--json",
 		"--port={{ .ServerPort }}",
 		"--client={{ .ServerAddressV4 }}",


### PR DESCRIPTION
The duration and interval are a pointer and must be dereferenced for the
fmt.Sprintf usage.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>