### PR TITLE
added pingparsing tester

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go get -v ./... && \
     go install -v ./...
 
-FROM galexrt/container-toolbox:v20200211
+FROM galexrt/container-toolbox:v20200211-232657-672
 LABEL maintainer="Alexander Trost <galexrt@googlemail.com> and Michal Janus <michal.janus@cloudical.io>"
 
 COPY --from=go-build /go/bin/app /bin/ancientt

--- a/cmd/ancientt/imports.go
+++ b/cmd/ancientt/imports.go
@@ -27,6 +27,7 @@ import (
 
 	// Parsers
 	_ "github.com/cloudical-io/ancientt/parsers/iperf3"
+	_ "github.com/cloudical-io/ancientt/parsers/pingparsing"
 
 	// Runners
 	_ "github.com/cloudical-io/ancientt/runners/ansible"
@@ -35,4 +36,5 @@ import (
 
 	// Testers
 	_ "github.com/cloudical-io/ancientt/testers/iperf3"
+	_ "github.com/cloudical-io/ancientt/testers/pingparsing"
 )

--- a/docs/config-structure.md
+++ b/docs/config-structure.md
@@ -23,6 +23,7 @@ This Document documents the types introduced by Ancientt for configuration to be
 * [KubernetesTimeouts](#kubernetestimeouts)
 * [MySQL](#mysql)
 * [Output](#output)
+* [PingParsing](#pingparsing)
 * [RunOptions](#runoptions)
 * [Runner](#runner)
 * [RunnerAnsible](#runneransible)
@@ -234,6 +235,19 @@ Output Output config structure pointing to the other config options for each out
 
 [Back to TOC](#table-of-contents)
 
+## PingParsing
+
+PingParsing PingParsing config structure for testers.Tester config
+
+| Field | Description | Scheme | Required | Validation |
+| ----- | ----------- | ------ | -------- | ---------- |
+| count | Count How many pings should be sent (default: `10`) | *int | true | required,min=1 |
+| deadline | Deadline Quote from pingparsing help output: \"Timeout before ping exits. valid time units are: d/day/days, h/hour/hours, m/min/mins/minute/minutes, s/sec/secs/second/seconds, ms/msec/msecs/millisecond/milliseconds, us/usec/usecs/microsecond/microseconds. if no unit string found, considered seconds as the time unit. see also ping(8) [-w deadline] option description. note: meaning of the 'deadline' may differ system to system.\" (default: `15s`) | *time.Duration | false |  |
+| timeout | Timeout Quote from the pingparsing help output: \"Time to wait for a response per packet. Valid time units are: d/day/days, h/hour/hours, m/min/mins/minute/minutes, s/sec/secs/second/seconds, ms/msec/msecs/millisecond/milliseconds, us/usec/usecs/microsecond/microseconds. if no unit string found, considered milliseconds as the time unit. Attempt to send packets with milliseconds granularity in default. If the system does not support timeout in milliseconds, round up as seconds. Use system default if not specified. This option will be ignored if the system does not support timeout itself. See also ping(8) [-W timeout] option description. note: meaning of the 'timeout' may differ system to system.\" (default: `10s`) | *time.Duration | false |  |
+| interface | Interface network interface to use for sending the pings. | string | false |  |
+
+[Back to TOC](#table-of-contents)
+
 ## RunOptions
 
 RunOptions options for running the tasks
@@ -326,7 +340,8 @@ Test Config options for each Test
 | outputs | List of Outputs to use for processing data from the testers. | [][Output](#output) | true | required,min=1 |
 | transformations | Transformations transformations to be applied to Output data | []*[Transformation](#transformation) | false |  |
 | hosts | Hosts selection for client and server | [TestHosts](#testhosts) | true |  |
-| iperf3 | IPerf3 test options | *[IPerf3](#iperf3) | true |  |
+| iperf3 | IPerf3 tester options | *[IPerf3](#iperf3) | true |  |
+| pingParsing | PingParsing tester options | *[PingParsing](#pingparsing) | true |  |
 
 [Back to TOC](#table-of-contents)
 

--- a/examples/runners/ansible/README.md
+++ b/examples/runners/ansible/README.md
@@ -8,3 +8,8 @@ ancientt --only-print-plan
 # Generate and execute the plan without user prompt
 ancientt --yes
 ```
+
+## Depdency Playbooks
+
+* [`depdendency-iperf3.yaml`](dependency-iperf3.yaml) - Installs `iperf3` and `procps` package for IPerf3 testing.
+* [`depdendency-pingparsing.yaml`](dependency-pingparsing.yaml) - Installs `pingparsing` (using `pip`) and `procps` package for IPerf3 testing. This also checks that Python 3.5+ is used for Ansible on the target hosts.

--- a/examples/runners/ansible/dependency-iperf3.yaml
+++ b/examples/runners/ansible/dependency-iperf3.yaml
@@ -1,8 +1,8 @@
 ---
 - hosts: all
   remote_user: root
-  tasks: 
-    - name: install dependencies for ACNTT
+  tasks:
+    - name: Install dependencies for Ancientt
       package: 
         name: "{{ item }}"
         state: present 

--- a/examples/runners/ansible/dependency-pingparsing.yaml
+++ b/examples/runners/ansible/dependency-pingparsing.yaml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  remote_user: root
+  tasks:
+    - name: Host Python must be at least 3.5+
+      assert:
+        that: "ansible_python_version is version_compare('3.5', '>=')"
+        msg: |
+          pingparsing requires at least python 3.5+ on th target machines
+    - name: Install dependencies for Ancientt
+      package: 
+        name: "{{ item }}"
+        state: present 
+      with_items:
+        - procps
+    - name: Pip install pingparsing package
+      pip:
+        name: pingparsing

--- a/examples/runners/ansible/testdefinition.yaml
+++ b/examples/runners/ansible/testdefinition.yaml
@@ -13,6 +13,12 @@ runner:
 tests:
 - name: iperf3-all-to-all
   type: iperf3
+  transformations:
+  - source: "bits_per_second"
+    destination: "gigabits_per_second"
+    action: "add"
+    modifier: 100000000
+    modifierAction: "division"
   outputs:
   - name: gochart
     goChart:

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.13
 require (
 	github.com/360EntSecGroup-Skylar/excelize/v2 v2.0.1
 	github.com/DATA-DOG/go-sqlmock v1.3.3
+	github.com/aws/aws-sdk-go v1.29.0
 	github.com/blend/go-sdk v2.0.0+incompatible // indirect
 	github.com/creasty/defaults v1.3.0
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
-	github.com/go-sql-driver/mysql v1.4.1
+	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/googleapis/gnostic v0.1.0 // indirect
@@ -28,7 +29,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.3.2
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	github.com/wcharczuk/go-chart v2.0.2-0.20190910040548-3a7bc5543113+incompatible
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f // indirect
 	golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aws/aws-sdk-go v1.29.0 h1:UFxrMQhDyLak6kVtOcr4PZxNRQV0s7pY/vKAyzRvi8c=
+github.com/aws/aws-sdk-go v1.29.0/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -47,6 +49,8 @@ github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415 h1:WSBJMqJbLxsn+bTCPyPYZfqHdJmc8MK4wrBjMft6BAM=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -86,6 +90,8 @@ github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be h1:AHimNtVIpiBjPUhEF5KNCkrUyqTSA5zWUl8sQ2bfGBE=
@@ -148,6 +154,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -185,6 +192,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/wcharczuk/go-chart v2.0.2-0.20190910040548-3a7bc5543113+incompatible h1:Bz/7IMIv+MmCANT7drP8zyxHH5xHC0/+smWpcJCCk4M=
 github.com/wcharczuk/go-chart v2.0.2-0.20190910040548-3a7bc5543113+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
@@ -206,6 +215,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0K86vlAs/eXGFms2txfJfA=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -316,8 +316,10 @@ type Test struct {
 	Transformations []*Transformation `yaml:"transformations,omitempty"`
 	// Hosts selection for client and server
 	Hosts TestHosts `yaml:"hosts"`
-	// IPerf3 test options
+	// IPerf3 tester options
 	IPerf3 *IPerf3 `yaml:"iperf3"`
+	// PingParsing tester options
+	PingParsing *PingParsing `yaml:"pingParsing"`
 }
 
 // RunMode custom run mode const type for
@@ -373,4 +375,25 @@ type IPerf3 struct {
 	Interval *int `yaml:"interval,omitempty" validate:"required,min=1"`
 	// If UDP should be used for the IPerf3 test
 	UDP *bool `yaml:"udp,omitempty"`
+}
+
+// PingParsing PingParsing config structure for testers.Tester config
+type PingParsing struct {
+	// Count How many pings should be sent (default: `10`)
+	Count *int `yaml:"count"  validate:"required,min=1"`
+	// Deadline Quote from pingparsing help output:
+	// "Timeout before ping exits. valid time units are: d/day/days, h/hour/hours, m/min/mins/minute/minutes, s/sec/secs/second/seconds, ms/msec/msecs/millisecond/milliseconds,
+	// us/usec/usecs/microsecond/microseconds. if no unit string found, considered seconds as the time unit. see also ping(8) [-w deadline] option description. note: meaning of the
+	// 'deadline' may differ system to system."
+	// (default: `15s`)
+	Deadline *time.Duration `yaml:"deadline,omitempty"`
+	// Timeout Quote from the pingparsing help output:
+	// "Time to wait for a response per packet. Valid time units are: d/day/days, h/hour/hours, m/min/mins/minute/minutes, s/sec/secs/second/seconds,
+	// ms/msec/msecs/millisecond/milliseconds, us/usec/usecs/microsecond/microseconds. if no unit string found, considered milliseconds as the time unit. Attempt to send packets with
+	// milliseconds granularity in default. If the system does not support timeout in milliseconds, round up as seconds. Use system default if not specified. This option will be
+	// ignored if the system does not support timeout itself. See also ping(8) [-W timeout] option description. note: meaning of the 'timeout' may differ system to system."
+	// (default: `10s`)
+	Timeout *time.Duration `yaml:"timeout,omitempty"`
+	// Interface network interface to use for sending the pings.
+	Interface string `yaml:"interface,omitempty"`
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -123,7 +123,7 @@ func (c *RunOptions) SetDefaults() {
 	}
 }
 
-// SetDefaults set defaults config part
+// SetDefaults set defaults on config part
 func (c *IPerf3) SetDefaults() {
 	if c.Duration == nil {
 		defValue := 10
@@ -137,6 +137,24 @@ func (c *IPerf3) SetDefaults() {
 
 	if c.UDP == nil {
 		c.UDP = util.BoolFalsePointer()
+	}
+}
+
+// SetDefaults set defaults on config part
+func (c *PingParsing) SetDefaults() {
+	if c.Count == nil {
+		defValue := 10
+		c.Count = &defValue
+	}
+
+	if c.Deadline == nil {
+		defValue := 15 * time.Second
+		c.Deadline = &defValue
+	}
+
+	if c.Timeout == nil {
+		defValue := 10 * time.Second
+		c.Timeout = &defValue
 	}
 }
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -29,12 +29,14 @@ type Executor interface {
 	ExecuteCommand(ctx context.Context, actionName string, command string, arg ...string) error
 	ExecuteCommandWithOutput(ctx context.Context, actionName string, command string, arg ...string) (string, error)
 	ExecuteCommandWithOutputByte(ctx context.Context, actionName string, command string, arg ...string) ([]byte, error)
+	SetEnv([]string)
 }
 
 // CommandExecutor Executor implementation
 type CommandExecutor struct {
 	Executor
 	logger *log.Entry
+	env    []string
 }
 
 // NewCommandExecutor create and return a new CommandExecutor
@@ -95,4 +97,9 @@ func (ce CommandExecutor) ExecuteCommandWithOutputByte(ctx context.Context, acti
 	}
 
 	return out, nil
+}
+
+// SetEnv set env for command execution
+func (ce CommandExecutor) SetEnv(e []string) {
+	ce.env = e
 }

--- a/pkg/executor/test/mock.go
+++ b/pkg/executor/test/mock.go
@@ -29,6 +29,9 @@ type MockExecutor struct {
 	MockExecuteCommand               func(ctx context.Context, actionName string, command string, arg ...string) error
 	MockExecuteCommandWithOutput     func(ctx context.Context, actionName string, command string, arg ...string) (string, error)
 	MockExecuteCommandWithOutputByte func(ctx context.Context, actionName string, command string, arg ...string) ([]byte, error)
+	MockSetEnv                       func(e []string)
+
+	env []string
 }
 
 // ExecuteCommand execute a given command with its arguments but don't return any output
@@ -75,4 +78,15 @@ func (ce MockExecutor) ExecuteCommandWithOutputByte(ctx context.Context, actionN
 	log.WithField("action", actionName).Debug(string(out))
 
 	return out, nil
+}
+
+// SetEnv set env for command execution
+func (ce MockExecutor) SetEnv(e []string) {
+	log.WithField("action", "setEnv()").Debugf("%+v", ce.env)
+	if ce.MockSetEnv != nil {
+		ce.MockSetEnv(e)
+		return
+	}
+
+	ce.env = e
 }

--- a/pkg/models/pingparsing/pingparsing.go
+++ b/pkg/models/pingparsing/pingparsing.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 Cloudical Deutschland GmbH. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pingparsing
+
+// ClientResults PingParsing Client Result map
+type ClientResults map[string]PingResult
+
+// PingResult Ping target client results structure
+type PingResult struct {
+	Destination          string      `json:"destination"`
+	PacketTransmit       int64       `json:"packet_transmit"`
+	PacketReceive        int64       `json:"packet_receive"`
+	PacketLossRate       float64     `json:"packet_loss_rate"`
+	PacketLossCount      int64       `json:"packet_loss_count"`
+	RTTMin               float64     `json:"rtt_min"`
+	RTTAvg               float64     `json:"rtt_avg"`
+	RTTMax               float64     `json:"rtt_max"`
+	RTTMDev              float64     `json:"rtt_mdev"`
+	PacketDuplicateRate  float64     `json:"packet_duplicate_rate"`
+	PacketDuplicateCount int64       `json:"packet_duplicate_count"`
+	ICMPReplies          []ICMPReply `json:"icmp_replies"`
+}
+
+// ICMPReply ICMP reply entry
+type ICMPReply struct {
+	Timestamp string  `json:"timestamp"`
+	ICMPSeq   int64   `json:"icmp_seq"`
+	TTL       int64   `json:"ttl"`
+	Time      float64 `json:"time"`
+	Duplicate bool    `json:"duplicate"`
+}

--- a/pkg/util/names.go
+++ b/pkg/util/names.go
@@ -14,7 +14,6 @@ limitations under the License.
 package util
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"time"
 )
@@ -31,9 +30,8 @@ const (
 
 // GetPNameFromTask get a "persistent" name for a task
 // This is done by calculating the checksums of the used names.
-func GetPNameFromTask(round int, hostname string, command string, args []string, role PNameRole) string {
-	data := fmt.Sprintf("%d-%s-%s", round, hostname, args)
-	return fmt.Sprintf("ancientt-%s-%s-%x", role, command, sha1.Sum([]byte(data)))
+func GetPNameFromTask(round int, hostname string, command string, role PNameRole, testStartTime time.Time) string {
+	return fmt.Sprintf("ancientt-%s-%s-%d", role, command, testStartTime.UnixNano())
 }
 
 // GetTaskName get a task name

--- a/pkg/util/pointers.go
+++ b/pkg/util/pointers.go
@@ -29,3 +29,8 @@ func BoolFalsePointer() *bool {
 func FloatPointer(in float64) *float64 {
 	return &in
 }
+
+// Int64Pointer return a pointer to a given int64
+func Int64Pointer(in int64) *int64 {
+	return &in
+}

--- a/runners/kubernetes/spec.go
+++ b/runners/kubernetes/spec.go
@@ -15,6 +15,7 @@ package kubernetes
 
 import (
 	"github.com/cloudical-io/ancientt/pkg/k8sutil"
+	"github.com/cloudical-io/ancientt/pkg/util"
 	"github.com/cloudical-io/ancientt/testers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,9 +52,10 @@ func (k Kubernetes) getPodSpec(pName string, taskName string, task *testers.Task
 			NodeSelector: map[string]string{
 				corev1.LabelHostname: task.Host.Name,
 			},
-			HostNetwork:   hostNetwork,
-			RestartPolicy: corev1.RestartPolicyOnFailure,
-			Tolerations:   k.config.Hosts.Tolerations,
+			HostNetwork:                   hostNetwork,
+			RestartPolicy:                 corev1.RestartPolicyOnFailure,
+			Tolerations:                   k.config.Hosts.Tolerations,
+			TerminationGracePeriodSeconds: util.Int64Pointer(5),
 		},
 	}
 

--- a/testdefinition.example.yaml
+++ b/testdefinition.example.yaml
@@ -3,7 +3,7 @@ runner:
   name: kubernetes
   kubernetes:
     #kubeconfig: .kube/config
-    image: 'quay.io/galexrt/container-toolbox:latest'
+    image: 'quay.io/galexrt/container-toolbox:v20200211-232657-672'
     namespace: ancientt
     timeouts:
       deleteTimeout: 20

--- a/testers/pingparsing/pingparsing_test.go
+++ b/testers/pingparsing/pingparsing_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 Cloudical Deutschland GmbH. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pingparsing
+
+import (
+	"testing"
+
+	"github.com/cloudical-io/ancientt/pkg/config"
+	"github.com/cloudical-io/ancientt/testers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIPerf3Plan(t *testing.T) {
+	tester, err := NewPingParsingTester(nil, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, tester)
+
+	env := &testers.Environment{
+		Hosts: &testers.Hosts{
+			Clients: map[string]*testers.Host{},
+			Servers: map[string]*testers.Host{},
+		},
+	}
+	test := &config.Test{
+		Type: "pingparsing",
+	}
+
+	plan, err := tester.Plan(env, test)
+	assert.Nil(t, err)
+	require.NotNil(t, plan)
+	assert.Equal(t, "pingparsing", plan.Tester)
+	assert.Equal(t, 0, len(plan.AffectedServers))
+	assert.Equal(t, 0, len(plan.Commands))
+}


### PR DESCRIPTION
This adds a new tester, pingparsing. [PingParsing](https://github.com/thombashi/pingparsing) allows for ping tests between servers.

In addition to that some issues with the kubernetes runner have been fixed.
> This fixes the "is node tolerated" check used in the "get host list"
function.
> Some other improvements have been made like setting a
TerminationGracePeriodSeconds on the Pods to `5` and reworked args passed
to `createPodsForTasks()` func.
